### PR TITLE
issue 20: fail2ban basic setup

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -40,6 +40,7 @@
           - libfontconfig1
           - vim
           - net-tools
+          - fail2ban
 
     - name: Fetching public keys
       import_tasks: tasks/fetching_keys.yml

--- a/tasks/fail2ban.yml
+++ b/tasks/fail2ban.yml
@@ -1,4 +1,0 @@
-- name: Install fail2ban packages
-  apt:
-    pkg:
-      - fail2ban

--- a/tasks/fail2ban.yml
+++ b/tasks/fail2ban.yml
@@ -1,0 +1,4 @@
+- name: Install fail2ban packages
+  apt:
+    pkg:
+      - fail2ban


### PR DESCRIPTION
Issue #20 

I can move the fail2ban install directly into the main playbook.yml file if needed.
Fail2ban launched automatically on my vagrant VM, it should be tested further.